### PR TITLE
Correct case of filename in #include directive

### DIFF
--- a/src/ArduinoUserInterface.h
+++ b/src/ArduinoUserInterface.h
@@ -34,7 +34,7 @@
 #ifndef ArduinoUserInterface_h
 #define ArduinoUserInterface_h
 
-#include "arduino.h"
+#include "Arduino.h"
 #include <avr/pgmspace.h>
 
 


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.